### PR TITLE
Fix CI path and remove stray newlines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,3 @@ jobs:
 
       - run: npm ci --no-audit --no-fund
       - run: npm test --if-present
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ejemplo mínimo de bot en Discord escrito en Node.js con soporte para ECMAScript
 - **package.json**: declara dependencias y el script de pruebas con Jest.
 - **src/index.js**: crea el cliente de Discord y maneja el evento `ready`.
 - **tests/**: carpeta para las pruebas automáticas; incluye un test inicial de ejemplo.
-- **.github/.workflows/ci.yml**: flujo de CI que instala dependencias y ejecuta `npm test`.
+- **.github/workflows/ci.yml**: flujo de CI que instala dependencias y ejecuta `npm test`.
 
 ## Aspectos clave
 


### PR DESCRIPTION
## Summary
- move CI workflow path to `.github/workflows/ci.yml`
- remove stray blank lines from the workflow
- update README to reference the new path

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446cc231508333b3b2e2960a580f61